### PR TITLE
El 3086 - Pass story’s ANS object to custom embed integration

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -64,6 +64,65 @@ Ready message should be send by a plugins as soon as it renders their content an
 
 If ready message will not be sent within ~10 seconds, Ellipsis will render a timeout error and plugin content will be discarded.
 
+Request additional Story ANS
+
+Customers can obtain addition ANS data from Ellipsis via `postMessage`. Ellipsis/Composer will send back the data with the additional fields of:
+
+1. Headlines
+2. Subheadlines
+3. Taxonomy
+
+To acheive this:
+- Add an additional flag `isAnsRequired` set to `true` in your API where `postMessage()` is happening.
+- `postMessage()` with Ready message `action = 'ready'`
+- E.g.
+```javascript
+  window.parent.postMessage(
+    JSON.stringify({
+      source: 'custom_embed',
+      action: 'ready',
+      data: { height: 900 },
+      key: parseQueryString()['k'],
+      isAnsRequired: false    // Change this to true
+    }),
+    targetOrigin
+  )
+```
+- Which will send out a message to Ellipsis/Composer that looks like:
+```javascript
+{source: "custom_embed", action: "ready", data: {…}, key: "1234567890", isAnsRequired: true}
+```
+- Ellipsis/Composer will postMessage back with additional Story ANS data:
+```javascript
+MessageEvent 
+{
+   "message":"ans_data",
+   "data":{
+      "headlines":{
+         "basic":"Test Headline",
+         "mobile":"",
+         "native":"",
+         ...
+      },
+      "subheadlines":{  "basic":"Test Sub Headline"},
+      "taxonomy":{
+         "sites":[{"_id":"/about-us", "type":"site", ...}],
+         "tags":[],
+         "sections":[],
+         ...
+      }
+   }
+}
+```
+#### Note
+- Ellipsis/Composer can send ANS back to Search, View, and Edit API
+- To receive, or check whats the result looks like, uncomment this example
+```javascript
+window.addEventListener('message', (e) => {
+  console.log(e)
+}, false)
+```
+
 Data message
 
 Data message should be send by search plugin when an item has been selected by user or edit plugin when editing is done. Data message should contain an embed data structure. Feel free to check the schema.
@@ -113,65 +172,7 @@ Message communication example
 |                                    | User accepted changes                                                                         |
 |                                    | ← {"source":"custom_embed","action":"data","key":"j0a","data":{…}}                                        |
 |                                    | /or/ User cancelled changes                                                                   |
-|                                    | ← {"source":"custom_embed","action":"cancel","key":"j0a"}                                                 |
-
-# Request additional Story ANS
-Customers can obtain addition ANS data from Ellipsis via `postMessage`. Ellipsis/Composer will send back the data with the additional fields of:
-
-1. Headlines
-2. Subheadlines
-3. Taxonomy
-
-To acheive this, simply
-- Add an additional flag `isAnsRequired` set to `true` in your API where `postMessage()` is happening. E.g.
-
-```javascript
-const sendMessage = function(action, data) {
-  window.parent.postMessage(
-    JSON.stringify({
-      source: 'custom_embed',
-      action,
-      data,
-      key: parseQueryString()['k'],
-      isAnsRequired: false    // Change this to true
-    }),
-    '*'
-  )
-}
-```
-- Which will send out a message to Ellipsis/Composer that looks like:
-```javascript
-{source: "custom_embed", action: "ready", data: {…}, key: "1234567890", isAnsRequired: true}
-```
-- Ellipsis/Composer will postMessage back with additional Story ANS data:
-```javascript
-MessageEvent 
-{
-   "message":"message",
-   "data":{
-      "headlines":{
-         "basic":"Test Headline",
-         "mobile":"",
-         "native":"",
-         ...
-      },
-      "subheadlines":{  "basic":"Test Sub Headline"},
-      "taxonomy":{
-         "sites":[{"_id":"/about-us", "type":"site", ...}],
-         "tags":[],
-         "sections":[],
-         ...
-      }
-   }
-}
-```
-#### Note
-- Example has been set up in the files `audioViewApi.html`, `audioSearchApi.html`, and `audioEditApi.html` under `/public` directory.
-- Ellipsis/Composer can send ANS back to Search, View, and Edit API
-- To receive, or check whats the result looks like, uncomment this part
-```javascript
-/*** Uncomment to see the received message ***/
-// window.addEventListener('message', (e) => {
-//   console.log(e)
-// }, false)
-```
+|                                    | ← {"source":"custom_embed","action":"cancel","key":"j0a"}                                     |
+| Ellipsis Sends Story ANS           |                                                                                               |
+|                                    | User requesting additional Story ANS                                                          |
+|                                    | ← {"source":"custom_embed","action":"ready",data: {…}, key: "j0a", isAnsRequired: true}       |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -66,13 +66,13 @@ If ready message will not be sent within ~10 seconds, Ellipsis will render a tim
 
 ### Request additional Story ANS
 
-Customers can obtain addition ANS data from Ellipsis via `postMessage`. It can be done with **Search**, **View**, and **Edit** APIs. Ellipsis/Composer will send back the data with the additional fields of:
+Customers can obtain addition ANS data from Ellipsis via `postMessage`. It can be done with **Search**, **View**, and **Edit** integration. Ellipsis/Composer will send back the data with the additional fields of:
 
 1. Headlines
 2. Subheadlines
 3. Taxonomy
 
-To do this, add an additional flag `isAnsRequired` set to `true` in your API where `postMessage()` is being called and when `action` is `'ready'`:
+To do this, add an additional flag `isAnsRequired` set to `true` in your integration where `postMessage()` is being called and when `action` is `'ready'`:
 ```javascript
 const sendMessage = function(action, data) {
   const messagePayload = {

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -114,3 +114,64 @@ Message communication example
 |                                    | ← {"source":"custom_embed","action":"data","key":"j0a","data":{…}}                                        |
 |                                    | /or/ User cancelled changes                                                                   |
 |                                    | ← {"source":"custom_embed","action":"cancel","key":"j0a"}                                                 |
+
+# Request additional Story ANS
+Customers can obtain addition ANS data from Ellipsis via `postMessage`. Ellipsis/Composer will send back the data with the additional fields of:
+
+1. Headlines
+2. Subheadlines
+3. Taxonomy
+
+To acheive this, simply
+- Add an additional flag `isAnsRequired` set to `true` in your API where `postMessage()` is happening. E.g.
+
+```javascript
+const sendMessage = function(action, data) {
+  window.parent.postMessage(
+    JSON.stringify({
+      source: 'custom_embed',
+      action,
+      data,
+      key: parseQueryString()['k'],
+      isAnsRequired: false    // Change this to true
+    }),
+    '*'
+  )
+}
+```
+- Which will send out a message to Ellipsis/Composer that looks like:
+```javascript
+{source: "custom_embed", action: "ready", data: {…}, key: "1234567890", isAnsRequired: true}
+```
+- Ellipsis/Composer will postMessage back with additional Story ANS data:
+```javascript
+MessageEvent 
+{
+   "message":"message",
+   "data":{
+      "headlines":{
+         "basic":"Test Headline",
+         "mobile":"",
+         "native":"",
+         ...
+      },
+      "subheadlines":{  "basic":"Test Sub Headline"},
+      "taxonomy":{
+         "sites":[{"_id":"/about-us", "type":"site", ...}],
+         "tags":[],
+         "sections":[],
+         ...
+      }
+   }
+}
+```
+#### Note
+- Example has been set up in the files `audioViewApi.html`, `audioSearchApi.html`, and `audioEditApi.html` under `/public` directory.
+- Ellipsis/Composer can send ANS back to Search, View, and Edit API
+- To receive, or check whats the result looks like, uncomment this part
+```javascript
+/*** Uncomment to see the received message ***/
+// window.addEventListener('message', (e) => {
+//   console.log(e)
+// }, false)
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2957,7 +2957,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2975,11 +2976,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2992,15 +2995,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3103,7 +3109,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3113,6 +3120,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3125,17 +3133,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3152,6 +3163,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3224,7 +3236,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3234,6 +3247,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3309,7 +3323,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3339,6 +3354,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3356,6 +3372,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3394,11 +3411,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -6478,7 +6497,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6496,11 +6516,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6513,15 +6535,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6624,7 +6649,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6634,6 +6660,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6646,17 +6673,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6673,6 +6703,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6745,7 +6776,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6755,6 +6787,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6830,7 +6863,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6860,6 +6894,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6877,6 +6912,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6915,11 +6951,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/public/audioEditApi.html
+++ b/public/audioEditApi.html
@@ -165,7 +165,6 @@
           action,
           data,
           key: parseQueryString()['k'],
-          isAnsRequired: false
         }),
         '*'
       )
@@ -226,9 +225,5 @@
     coverImage.src = dataHolder.data.config.cover_art_url
     document.getElementById('btn_apply').onclick = applyChanges
     document.getElementById('btn_cancel').onclick = dismissEditor
-    /*** Uncomment to see the received message ***/
-    // window.addEventListener('message', (e) => {
-    //   console.log(e)
-    // }, false)
   </script>
 </html>

--- a/public/audioEditApi.html
+++ b/public/audioEditApi.html
@@ -164,7 +164,8 @@
           source: 'custom_embed',
           action,
           data,
-          key: parseQueryString()['k']
+          key: parseQueryString()['k'],
+          isAnsRequired: false
         }),
         '*'
       )
@@ -225,5 +226,9 @@
     coverImage.src = dataHolder.data.config.cover_art_url
     document.getElementById('btn_apply').onclick = applyChanges
     document.getElementById('btn_cancel').onclick = dismissEditor
+    /*** Uncomment to see the received message ***/
+    // window.addEventListener('message', (e) => {
+    //   console.log(e)
+    // }, false)
   </script>
 </html>

--- a/public/audioSearchApi.html
+++ b/public/audioSearchApi.html
@@ -238,7 +238,6 @@
             action,
             data,
             key: parseQueryString()['k'],
-            isAnsRequired: false,
           }),
           '*'
         )
@@ -355,11 +354,6 @@
 
         Amplitude.init({ songs })
       }
-
-      /*** Uncomment to see the received message ***/
-      // window.addEventListener('message', (e) => {
-      //   console.log(e)
-      // }, false)
     </script>
   </body>
 </html>

--- a/public/audioSearchApi.html
+++ b/public/audioSearchApi.html
@@ -239,7 +239,7 @@
           key: parseQueryString()['k']
         }
         if (action === 'ready') {
-          messagePayload.isAnsRequired = false
+          messagePayload.isAnsRequired = true
         }
         window.parent.postMessage(JSON.stringify(messagePayload), '*')
       }

--- a/public/audioSearchApi.html
+++ b/public/audioSearchApi.html
@@ -37,7 +37,7 @@
       .list-group-item-action:hover:not(.active),
       .list-group-item-action:visited:not(.active) {
         color: #495057;
-        background-color: white;        
+        background-color: white;
       }
       .active-animate {
         animation: flash-animation 1000ms 1;
@@ -56,7 +56,7 @@
           background-color: white;
           border-color: white;
         }
-      }      
+      }
     </style>
   </head>
   <body>
@@ -237,7 +237,8 @@
             source: 'custom_embed',
             action,
             data,
-            key: parseQueryString()['k']
+            key: parseQueryString()['k'],
+            isAnsRequired: false,
           }),
           '*'
         )
@@ -304,7 +305,7 @@
           return
         }
         listGroupItem.classList.add('active-animate')
-        
+
         setTimeout(() => {
           sendMessage('data', {
             id: `aud-${index}`,
@@ -354,6 +355,11 @@
 
         Amplitude.init({ songs })
       }
+
+      /*** Uncomment to see the received message ***/
+      // window.addEventListener('message', (e) => {
+      //   console.log(e)
+      // }, false)
     </script>
   </body>
 </html>

--- a/public/audioSearchApi.html
+++ b/public/audioSearchApi.html
@@ -232,15 +232,16 @@
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/amplitudejs@4.1.0/dist/amplitude.js"></script>
     <script>
       const sendMessage = function(action, data) {
-        window.parent.postMessage(
-          JSON.stringify({
-            source: 'custom_embed',
-            action,
-            data,
-            key: parseQueryString()['k'],
-          }),
-          '*'
-        )
+        const messagePayload = {
+          source: 'custom_embed',
+          action,
+          data,
+          key: parseQueryString()['k']
+        }
+        if (action === 'ready') {
+          messagePayload.isAnsRequired = false
+        }
+        window.parent.postMessage(JSON.stringify(messagePayload), '*')
       }
 
       const parseQueryString = function() {

--- a/public/audioViewApi.html
+++ b/public/audioViewApi.html
@@ -102,7 +102,8 @@
           source: 'custom_embed',
           action,
           data,
-          key: parseQueryString()['k']
+          key: parseQueryString()['k'],
+          isAnsRequired: true,
         }),
         '*'
       )
@@ -159,5 +160,10 @@
       checkInit()
     }
     coverImage.src = data.config.cover_art_url
+
+    /*** Uncomment to see the received message ***/
+    // window.addEventListener('message', (e) => {
+    //   console.log(e)
+    // }, false)
   </script>
 </html>

--- a/public/audioViewApi.html
+++ b/public/audioViewApi.html
@@ -103,7 +103,6 @@
           action,
           data,
           key: parseQueryString()['k'],
-          isAnsRequired: true,
         }),
         '*'
       )
@@ -161,9 +160,5 @@
     }
     coverImage.src = data.config.cover_art_url
 
-    /*** Uncomment to see the received message ***/
-    // window.addEventListener('message', (e) => {
-    //   console.log(e)
-    // }, false)
   </script>
 </html>


### PR DESCRIPTION
[El 3086 - Pass story’s ANS object to custom embed integration](https://arcpublishing.atlassian.net/browse/EL-3086)

Pass the story's ANS object to the custom embed iframes so that customers can tailor their iframes to the story.

The additional fields are 
1. Headlines,
2. Subheadlines,
3. Taxonomy

Documentation has also been updated accordingly in `docs/reference.md`
